### PR TITLE
Add basic science experiment "Kethane Scan"

### DIFF
--- a/Parts/kethane_highGain/part.cfg
+++ b/Parts/kethane_highGain/part.cfg
@@ -60,4 +60,25 @@ MODULE
     ElevationTransform = geo_dishHighGain
 }
 
+MODULE {
+    name = ModuleScienceExperiment
+
+    experimentID = kethaneScan
+
+    experimentActionName = Gather Kethane Scan
+    resetActionName = Reset Kethane Scan
+
+    useStaging = False
+    useActionGroups = True
+    hideUIwhenUnavailable = True
+
+    xmitDataScalar = 0.3
+
+    FxModules = 0
+
+    dataIsCollectable = True
+    collectActionName = Collect Data
+    interactionRange = 1.2
+}
+
 }

--- a/Resources/Kethane.cfg
+++ b/Resources/Kethane.cfg
@@ -66,3 +66,21 @@ KethaneResource
     }
   }
 }
+
+EXPERIMENT_DEFINITION
+{
+  id = kethaneScan
+  title = Kethane Scan
+  baseValue = 50
+  scienceCap = 500
+  dataScale = 10
+
+  requireAtmosphere = False
+  situationMask = 16
+  biomeMask = 7
+
+  RESULTS
+  {
+    default = Chirp Chirp Choop goes the scanner.
+  }
+}


### PR DESCRIPTION
This is a really bad way to add science to Kethan - the Small Scanner Unit behaves like a science experiment that can gather 50 science at a time, up to 500 science. (This is not how Squad's science is balanced.) A better solution would be adding science per kethan square scanned.

See the conversation in #228
