### PR TITLE
KSPAssembly for mod dependency

### DIFF
--- a/Plugin/Properties/AssemblyInfo.cs
+++ b/Plugin/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyInformationalVersion("0.8.6")]
+[assembly: KSPAssembly("Kethane", 8, 6)]


### PR DESCRIPTION
Better support for mods with hard dependency on Kethane.dll by adding:

[assembly: KSPAssemblyDependency ("Kethane", 8, 6)] 

to those mods.
